### PR TITLE
Add port configuration for MikroTik backup

### DIFF
--- a/inventory.example
+++ b/inventory.example
@@ -1,2 +1,2 @@
 [mikrotik]
-192.168.1.1 ansible_user=admin ansible_ssh_pass='password'
+192.168.1.1 ansible_user=admin ansible_ssh_pass='password' ansible_port=22

--- a/main.yml
+++ b/main.yml
@@ -3,6 +3,10 @@
   gather_facts: no
   tasks:
 
+    - name: Set ssh port (set defualt 22 port when port is not defined)
+      set_fact:
+        ansible_port: "{{ ansible_port | default(22) }}"
+
     - name: Run backup with password (when password is defined)
       when: ansible_ssh_pass is defined
       block:

--- a/main.yml
+++ b/main.yml
@@ -23,7 +23,7 @@
       - name: gather export (with password authentication)
         # shell with delegate_to: localhost works better that ansible.builtin.raw  
         ansible.builtin.shell: >-
-          sshpass -p '{{ ansible_ssh_pass }}' ssh -o StrictHostKeyChecking=no {{ ansible_user }}@{{ inventory_hostname }} /export
+          sshpass -p '{{ ansible_ssh_pass }}' ssh -o StrictHostKeyChecking=no {{ ansible_user }}@{{ inventory_hostname }} -p {{ ansible_port }} /export
         register: export
         delegate_to: localhost
 
@@ -41,7 +41,7 @@
       - name: gather export (with passwordless authentication)
         # shell with delegate_to: localhost works better that ansible.builtin.raw  
         ansible.builtin.shell: >-
-          ssh {{ ansible_user }}@{{ inventory_hostname }} /export
+          ssh {{ ansible_user }}@{{ inventory_hostname }} -p {{ ansible_port }} /export
         register: export
         delegate_to: localhost
 


### PR DESCRIPTION
This PR added the ability to change the SSH port for routers through the ansible_port variable in the playbook and the inventory.example file.
